### PR TITLE
Fix warning about conflicting behaviours

### DIFF
--- a/lib/repo/repo.ex
+++ b/lib/repo/repo.ex
@@ -197,10 +197,6 @@ defmodule ExAudit.Repo do
         end
       end
 
-      def default_options(_operation), do: []
-
-      defoverridable(default_options: 1)
-
       defoverridable(child_spec: 1)
 
       # additional functions
@@ -237,6 +233,4 @@ defmodule ExAudit.Repo do
   """
   @callback revert(version :: struct, opts :: list) ::
               {:ok, struct} | {:error, changeset :: Ecto.Changeset.t()}
-
-  @callback default_options(operation :: atom) :: keyword
 end


### PR DESCRIPTION
warning: conflicting behaviours found. function default_options/1 is required by Ecto.Repo and ExAudit.Repo